### PR TITLE
docs: remove --num-samples arg

### DIFF
--- a/p2d/README.cn.md
+++ b/p2d/README.cn.md
@@ -6,7 +6,7 @@
 ## 命令行使用示例
 ```bash
 # 首先把你的 polygon-package 解压到 /path/to/polygon-package 位置 
-$ ./bin/p2d --code A --num-samples 2 --color FF0000 -o /path/to/domjudge-package /path/to/polygon-package
+$ ./bin/p2d --code A --color FF0000 -o /path/to/domjudge-package /path/to/polygon-package
 ```
 运行此命令可以从 `/path/to/polygon-package` 处的转换题目包为 `/path/to/domjudge-package.zip`，并设置  `probcode` 和 `color` 属性。
 

--- a/p2d/README.md
+++ b/p2d/README.md
@@ -8,7 +8,7 @@ It is a simple python script converting polygon package to domjudge(kattis) pack
 ## CLI Example
 ```bash
 # Unzip your polygon-package to /path/to/polygon-package first
-$ ./bin/p2d --code A --num-samples 2 --color FF0000 -o /path/to/domjudge-package /path/to/polygon-package
+$ ./bin/p2d --code A --color FF0000 -o /path/to/domjudge-package /path/to/polygon-package
 ```
 Run this command to make a package from `/path/to/polygon-package` to `/path/to/domjudge-package.zip` and set `probcode` and `color`.
 


### PR DESCRIPTION
样例的数量已经可以从 `problem.xml` 中获取了，所以可以移除使用示例中的 `--num-samples`